### PR TITLE
Enable Editor for Codespace to find semantic_kernel

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python.analysis.extraPaths": [
+        "./semantic-kernel/python"
+    ]
+}


### PR DESCRIPTION
This commit enables the Python analysis of the included semantic_kernel package and gets rid of the warnings in the Jupyter Notebooks